### PR TITLE
Filter out "empty" directories in theme specification file

### DIFF
--- a/lib/theme/index.js
+++ b/lib/theme/index.js
@@ -86,6 +86,7 @@ class Theme {
 		this.directories = iconThemeSection.get( "directories" )
 			.split( "," )
 			.map( directory => directory.trim() )
+			.filter( directory => directory !== "" )
 			.reduce( ( directories, directory ) => {
 				if ( !sections.has( directory ) ) {
 					throw new Error( `Missing directory section for ${directory}` );

--- a/test/theme/index.js
+++ b/test/theme/index.js
@@ -61,7 +61,7 @@ test( "Theme constructor", t => {
 	);
 
 	const theme = new Theme( "foobar", new Map([
-		[ "Icon Theme", new Map([ [ "directories", " foo , bar " ] ]) ],
+		[ "Icon Theme", new Map([ [ "directories", " foo , bar , " ] ]) ],
 		[ "foo", new Map([ [ "size", 32 ] ]) ],
 		[ "bar", new Map([ [ "size", 64 ] ]) ]
 	]) );


### PR DESCRIPTION
The /usr/share/icons/Adwaita/index.theme file on Arch linuc has a trailing
comma in the Directories= stanza, meaning it can't be loaded.